### PR TITLE
Make ResourceIdentifier.type/id/toDictionary() public access level.

### DIFF
--- a/Spine/Resource.swift
+++ b/Spine/Resource.swift
@@ -13,10 +13,10 @@ public typealias ResourceType = String
 /// A ResourceIdentifier uniquely identifies a resource that exists on the server.
 public struct ResourceIdentifier: Equatable {
 	/// The resource type.
-	var type: ResourceType
+	public var type: ResourceType
 	
 	/// The resource ID.
-	var id: String
+	public var id: String
 
 	/// Constructs a new ResourceIdentifier instance with given `type` and `id`.
 	init(type: ResourceType, id: String) {
@@ -32,7 +32,7 @@ public struct ResourceIdentifier: Equatable {
 	}
 
 	/// Returns a dictionary with "type" and "id" keys containing the type and id.
-	func toDictionary() -> NSDictionary {
+	public func toDictionary() -> NSDictionary {
 		return ["type": type, "id": id]
 	}
 }

--- a/Spine/Resource.swift
+++ b/Spine/Resource.swift
@@ -13,10 +13,10 @@ public typealias ResourceType = String
 /// A ResourceIdentifier uniquely identifies a resource that exists on the server.
 public struct ResourceIdentifier: Equatable {
 	/// The resource type.
-	public var type: ResourceType
+	public private(set) var type: ResourceType
 	
 	/// The resource ID.
-	public var id: String
+	public private(set) var id: String
 
 	/// Constructs a new ResourceIdentifier instance with given `type` and `id`.
 	init(type: ResourceType, id: String) {


### PR DESCRIPTION
Change access level of `ResourceIdentifier.type`, `ResourceIdentifier.id` and `ResourceIdentifier.toDictionary()` from **internal** to **public**, to give access to other modules.