### PR TITLE
Support resource identifier metadata

### DIFF
--- a/Spine/DeserializeOperation.swift
+++ b/Spine/DeserializeOperation.swift
@@ -300,7 +300,7 @@ class DeserializeOperation: Operation {
 			let linkURL: URL? = linkData["links"]?["self"].url
 			
 			if let linkage = linkData["data"]?.array {
-				let mappedLinkage = linkage.map { ResourceIdentifier(type: $0["type"].stringValue, id: $0["id"].stringValue) }
+				let mappedLinkage = linkage.map { ResourceIdentifier(type: $0["type"].stringValue, id: $0["id"].stringValue, meta: $0["meta"].dictionaryObject) }
 				resourceCollection = LinkedResourceCollection(resourcesURL: resourcesURL, linkURL: linkURL, linkage: mappedLinkage)
 			} else {
 				resourceCollection = LinkedResourceCollection(resourcesURL: resourcesURL, linkURL: linkURL, linkage: nil)
@@ -321,10 +321,10 @@ class DeserializeOperation: Operation {
 		let data: [ResourceIdentifier]?
 		
 		if let toOne = linkData["data"].dictionary {
-			data = [ResourceIdentifier(type: toOne["type"]!.stringValue, id: toOne["id"]!.stringValue)]
+			data = [ResourceIdentifier(type: toOne["type"]!.stringValue, id: toOne["id"]!.stringValue, meta: toOne["meta"]?.dictionaryObject)]
 		} else if let toMany = linkData["data"].array {
 			data = toMany.map { JSON -> ResourceIdentifier in
-				return ResourceIdentifier(type: JSON["type"].stringValue, id: JSON["id"].stringValue)
+				return ResourceIdentifier(type: JSON["type"].stringValue, id: JSON["id"].stringValue, meta: JSON["meta"].dictionaryObject)
 			}
 		} else {
 			data = nil

--- a/Spine/Resource.swift
+++ b/Spine/Resource.swift
@@ -18,10 +18,14 @@ public struct ResourceIdentifier: Equatable {
 	/// The resource ID.
 	public private(set) var id: String
 
-	/// Constructs a new ResourceIdentifier instance with given `type` and `id`.
-	init(type: ResourceType, id: String) {
+	/// Optional non-standard meta-information.
+	public private(set) var meta: [String: Any]?
+	
+	/// Constructs a new ResourceIdentifier instance with given `type`, `id` and `meta`.
+	init(type: ResourceType, id: String, meta: [String: Any]?) {
 		self.type = type
 		self.id = id
+		self.meta = meta
 	}
 
 	/// Constructs a new ResourceIdentifier instance from the given dictionary.
@@ -29,11 +33,16 @@ public struct ResourceIdentifier: Equatable {
 	init(dictionary: NSDictionary) {
 		type = dictionary["type"] as! ResourceType
 		id = dictionary["id"] as! String
+		meta = dictionary["meta"] as? [String: Any]
 	}
 
 	/// Returns a dictionary with "type" and "id" keys containing the type and id.
 	public func toDictionary() -> NSDictionary {
-		return ["type": type, "id": id]
+		var dictionary: [String: Any] = ["type": type, "id": id]
+		if let meta = meta {
+			dictionary["meta"] = meta
+		}
+		return dictionary as NSDictionary
 	}
 }
 

--- a/Spine/SerializeOperation.swift
+++ b/Spine/SerializeOperation.swift
@@ -162,7 +162,7 @@ class SerializeOperation: Operation {
 		
 		if let resources = linkedResources?.resources {
 			resourceIdentifiers = resources.filter { $0.id != nil }.map { resource in
-				return ResourceIdentifier(type: resource.resourceType, id: resource.id!)
+				return ResourceIdentifier(type: resource.resourceType, id: resource.id!, meta: nil)
 			}
 		}
 		

--- a/SpineTests/ResourceCollectionTests.swift
+++ b/SpineTests/ResourceCollectionTests.swift
@@ -59,7 +59,7 @@ class LinkedResourceCollectionTests: XCTestCase {
 	func testInitWithResourcesURLAndURLAndLinkage() {
 		let resourcesURL = URL(string: "http://example.com/foos")!
 		let linkURL = URL(string: "http://example.com/bars/1/link/foos")!
-		let linkage = [ResourceIdentifier(type: "foos", id: "1"), ResourceIdentifier(type: "bars", id: "2")]
+		let linkage = [ResourceIdentifier(type: "foos", id: "1", meta: ["foo": "bar"]), ResourceIdentifier(type: "bars", id: "2", meta: ["baz": "buz"])]
 		let collection = LinkedResourceCollection(resourcesURL: resourcesURL, linkURL: linkURL, linkage: linkage)
 		
 		XCTAssertNotNil(collection.resourcesURL, "Expected resources URL to be not nil.")
@@ -76,7 +76,7 @@ class LinkedResourceCollectionTests: XCTestCase {
 	func testInitWithResourcesURLAndURLAndHomogenousTypeAndLinkage() {
 		let resourcesURL = URL(string: "http://example.com/foos")!
 		let linkURL = URL(string: "http://example.com/bars/1/link/foos")!
-		let collection = LinkedResourceCollection(resourcesURL: resourcesURL, linkURL: linkURL, linkage: ["1", "2"].map { ResourceIdentifier(type: "foos", id: $0) })
+		let collection = LinkedResourceCollection(resourcesURL: resourcesURL, linkURL: linkURL, linkage: ["1", "2"].map { ResourceIdentifier(type: "foos", id: $0, meta: ["foo": "bar"]) })
 		
 		XCTAssertNotNil(collection.resourcesURL, "Expected resources URL to be not nil.")
 		XCTAssertEqual(collection.resourcesURL!, resourcesURL, "Expected resources URL to be equal.")
@@ -85,8 +85,8 @@ class LinkedResourceCollectionTests: XCTestCase {
 		XCTAssertEqual(collection.linkURL!, linkURL, "Expected link URL to be equal.")
 		
 		XCTAssert(collection.linkage != nil, "Expected linkage to be not nil.")
-		XCTAssertEqual(collection.linkage![0], ResourceIdentifier(type: "foos", id: "1"), "Expected first linkage item to be equal.")
-		XCTAssertEqual(collection.linkage![1], ResourceIdentifier(type: "foos", id: "2"), "Expected second linkage item to be equal.")
+		XCTAssertEqual(collection.linkage![0], ResourceIdentifier(type: "foos", id: "1", meta: ["foo": "bar"]), "Expected first linkage item to be equal.")
+		XCTAssertEqual(collection.linkage![1], ResourceIdentifier(type: "foos", id: "2", meta: ["foo": "bar"]), "Expected second linkage item to be equal.")
 	}
 	
 	func testAppendResource() {


### PR DESCRIPTION
Adds basic support for metadata on resource identifiers, as [described in the spec](http://jsonapi.org/format/#document-resource-identifier-objects):

> A “resource identifier object” **MAY** also include a meta member, whose value is a [meta](http://jsonapi.org/format/#document-meta) object that contains non-standard meta-information.

Our project uses that meta information to convey preferred sort order on a relation. The server does not guarantee preserved array ordering, so we need to use that metadata.

I'm aware the API for this is not optimal; I'll have to access `<collection>.linkage` and then map its metadata to each resource by myself. API-wise I would prefer having a `ResourceIdentifier.resource` accessor for convenience, but I believe it would lead to a lot of work for a comparatively small gain.

All tests are passing, and I have manually run this against our production back-end to verify that I can access the metadata as described.