### PR TITLE
Added possibility to add custom URL parameters

### DIFF
--- a/Spine/Query.swift
+++ b/Spine/Query.swift
@@ -41,6 +41,7 @@ public struct Query<T: Resource> {
 	
 	public internal(set) var pagination: Pagination?
 	
+    public internal(set) var customURLparams: [String: String] = [:]
 	
 	//MARK: Init
 	
@@ -274,6 +275,17 @@ public struct Query<T: Resource> {
 	public mutating func paginate(_ pagination: Pagination?) {
 		self.pagination = pagination
 	}
+    
+    
+    // MARK: Custom URL params
+    
+    /// Add custom URL parameter. Pass value=nil to remove parameter.
+    ///
+    /// - parameter key: key of added parameter
+    /// - parameter value: value of added parameter   (URL...&key=value&...)
+    public mutating func addCustomURLparameter(_ key: String, value: String?) {
+        self.customURLparams[key] = value
+    }
 }
 
 

--- a/Spine/Routing.swift
+++ b/Spine/Routing.swift
@@ -176,6 +176,13 @@ open class JSONAPIRouter: Router {
 			}
 		}
 
+        // Custom URL params
+        for itemKey in query.customURLparams.keys {
+            let value = query.customURLparams[itemKey]
+            let item = URLQueryItem(name: itemKey, value: value)
+            appendQueryItem(item, to: &queryItems)
+        }
+        
 		// Compose URL
 		if !queryItems.isEmpty {
 			urlComponents.queryItems = queryItems


### PR DESCRIPTION
viz #14 

usage:
```swift
var query = Query(resourceType: SomeResource.self)
query.include("test")
query.addDescendingOrder("updatedAt")
query.addCustomURLparameter("customKey", value: "customVal")
```

result URL will be:
someserver.com/api/some?include=test&sort=-updatedAt&customKey=customVal
